### PR TITLE
Added xml data source

### DIFF
--- a/app/src/main/java/com/antgut/moviesapp/data/local/xml/XmlLocalDataSource.kt
+++ b/app/src/main/java/com/antgut/moviesapp/data/local/xml/XmlLocalDataSource.kt
@@ -1,0 +1,39 @@
+package com.antgut.moviesapp.data.local.xml
+
+import android.content.SharedPreferences
+import com.antgut.app.data.local.db.commons.KSerializer
+import com.antgut.moviesapp.data.local.LocalDataRepository
+import com.antgut.moviesapp.domain.Movie
+
+class XmlLocalDataSource(
+    private val sharedPref: SharedPreferences,
+    private val kserializer: KSerializer
+) :
+    LocalDataRepository {
+
+    private val editor: SharedPreferences.Editor = sharedPref.edit()
+
+    override fun getMovie(id: String): Movie {
+        return sharedPref.getString(id, null).let {
+            kserializer.fromJson(it, Movie::class.java)
+        }
+    }
+
+    override fun getMovies(): List<Movie> {
+        val list = mutableListOf<Movie>()
+        sharedPref.all.forEach {
+            editor.apply {
+                list.add(kserializer.fromJson(it.value as String, Movie::class.java))
+            }.apply()
+        }
+        return list
+    }
+
+    override fun saveMovies(list: List<Movie>) {
+        list.forEach {
+            editor.putString(it.id, kserializer.toJson(it, Movie::class.java))
+        }
+        editor.apply()
+    }
+
+}


### PR DESCRIPTION
## Description de la tarea

In this branch I implement xml as a local source. We also need KSerializer, but it was alredy implemented.

## ¿Cómo se ha implementado?

I created only one file, because KSerializer was already implemented when I started the project,
in the kserializer I created an abstraction so we could use it in all the app without the need of having to instantiate each time.
The file i added also is XmlLocalDataSource, in this one we implement the three methods in our LocalDataRepository to be used with xml

## Keywords

LocalSource, XML, SharedPreferences, KSerializer
